### PR TITLE
removed dependence on an internal lookup table.

### DIFF
--- a/fitbit-memory-test/app/index.js
+++ b/fitbit-memory-test/app/index.js
@@ -1,30 +1,115 @@
 import { memory } from "system";
 import Register from "../../index.js"
-var reg = new Register();
-reg.newInt('ab',1);
-// reg.newInt('b',1);
-// reg.newInt('c',1);
-// reg.newInt('d',1);
-// reg.newInt('e',1);
-console.log(memory.js.used);
-// console.log("1 JS memory: " + memory.js.used + "/" + memory.js.total + ' (' + Math.floor(memory.js.used/memory.js.total*100) + '%) ' + memory.monitor.pressure );
 
+// stress test
+const reg = new Register(3);
+const a = reg.newInt(1);
+const b = reg.newInt(1);
+const c = reg.newInt(1);
+const d = reg.newInt(1);
+const e = reg.newInt(1);
+const f = reg.newInt(1);
+const g = reg.newInt(1);
+const h = reg.newInt(1);
+// const a1 = reg.newInt(1);
+// const b1 = reg.newInt(1);
+// const c1 = reg.newInt(1);
+// const d1 = reg.newInt(1);
+// const e1 = reg.newInt(1);
+// const f1 = reg.newInt(1);
+// const g1 = reg.newInt(1);
+// const h1 = reg.newInt(1);
+// const a2 = reg.newInt(1);
+// const b2 = reg.newInt(1);
+// const c2 = reg.newInt(1);
+// const d2 = reg.newInt(1);
+// const e2 = reg.newInt(1);
+// const f2 = reg.newInt(1);
+// const g2 = reg.newInt(1);
+// const h2 = reg.newInt(1);
+// const a3 = reg.newInt(1);
+// const b3 = reg.newInt(1);
+// const c3 = reg.newInt(1);
+// const d3 = reg.newInt(1);
+// const e3 = reg.newInt(1);
+// const f3 = reg.newInt(1);
+// const g3 = reg.newInt(1);
+// const h3 = reg.newInt(1);
+// //32
 
-// reg.newInt('a',8);
-// reg.newInt('b',8);
-// reg.newInt('c',8);
-// reg.newInt('d',8);
+// const a4 = reg.newInt(1);
+// const b4 = reg.newInt(1);
+// const c4 = reg.newInt(1);
+// const d4 = reg.newInt(1);
+// const e4 = reg.newInt(1);
+// const f4 = reg.newInt(1);
+// const g4 = reg.newInt(1);
+// const h4 = reg.newInt(1);
+// const a5 = reg.newInt(1);
+// const b5 = reg.newInt(1);
+// const c5 = reg.newInt(1);
+// const d5 = reg.newInt(1);
+// const e5 = reg.newInt(1);
+// const f5 = reg.newInt(1);
+// const g5 = reg.newInt(1);
+// const h5 = reg.newInt(1);
+// const a6 = reg.newInt(1);
+// const b6 = reg.newInt(1);
+// const c6 = reg.newInt(1);
+// const d6 = reg.newInt(1);
+// const e6 = reg.newInt(1);
+// const f6 = reg.newInt(1);
+// const g6 = reg.newInt(1);
+// const h6 = reg.newInt(1);
+// const a7 = reg.newInt(1);
+// const b7 = reg.newInt(1);
+// const c7 = reg.newInt(1);
+// const d7 = reg.newInt(1);
+// const e7 = reg.newInt(1);
+// const f7 = reg.newInt(1);
+// const g7 = reg.newInt(1);
+// const h7 = reg.newInt(1);
+// // 64
 
-// reg.newInt('a1',8);
-// reg.newInt('b1',8);
-// reg.newInt('c1',8);
-// reg.newInt('d1',8);
+// const a8 = reg.newInt(1);
+// const b8 = reg.newInt(1);
+// const c8 = reg.newInt(1);
+// const d8 = reg.newInt(1);
+// const e8 = reg.newInt(1);
+// const f8 = reg.newInt(1);
+// const g8 = reg.newInt(1);
+// const h8 = reg.newInt(1);
+// const a9 = reg.newInt(1);
+// const b9 = reg.newInt(1);
+// const c9 = reg.newInt(1);
+// const d9 = reg.newInt(1);
+// const e9 = reg.newInt(1);
+// const f9 = reg.newInt(1);
+// const g9 = reg.newInt(1);
+// const h9 = reg.newInt(1);
+// const aa = reg.newInt(1);
+// const ba = reg.newInt(1);
+// const ca = reg.newInt(1);
+// const da = reg.newInt(1);
+// const ea = reg.newInt(1);
+// const fa = reg.newInt(1);
+// const ga = reg.newInt(1);
+// const ha = reg.newInt(1);
+// const ab = reg.newInt(1);
+// const bb = reg.newInt(1);
+// const cb = reg.newInt(1);
+// const db = reg.newInt(1);
+// const eb = reg.newInt(1);
+// const fb = reg.newInt(1);
+// const gb = reg.newInt(1);
+// const hb = reg.newInt(1);
+// 96
 
-// // reg._lookup = null;
-
-// // var a = 1;
-// // var b = 2;
-// // var c = 3;
-// // var d = 4;
-
-// console.log("2 JS memory: " + memory.js.used + "/" + memory.js.total + ' (' + Math.floor(memory.js.used/memory.js.total*100) + '%) ' + memory.monitor.pressure );
+// monitor memory usage and trigger garbage collection.
+setInterval(function(){
+	// check our memory
+	console.log(memory.js.used);
+	// fill up a bunch of memory to try and trigger garbage collection
+	var buff = new Uint32Array(50);// gc roughly every 13 seconds
+	buff.toString()
+},1000);

--- a/fitbit-memory-test/memory.md
+++ b/fitbit-memory-test/memory.md
@@ -1,6 +1,21 @@
 # Memory
 
+Attempting to measure memory usage is difficult because every bit of code you write to measure or test it adds to your memory usage.
+
+When you call functions, the memory usage balloons rapidly, but then collapses on the next garbage collection which can't be predicted.
+
+The best way to spot memory usage is to console.log the memory every second. Spotting the garbage collection is easy because your memory usage can drop from (for example) 75000 to 13000 in a second.
+
+When the memory drops after GC, the next memory reading is closer to your actual memory usage. Using the Register class, it is very low.
+
+However, without actually using these variables its hard to tell how the impact on real memory usage is. So, I guess I'll just have to try it in prod.
+
+I suspect garbage collection happens more often with higher memory pressure, so when your app is running it probably triggers more often.
+
 Maximum memory alloc is 131064 according to memory.js.total.
+
+12888 after 15 seconds....?
+13240 after 96 new variables!
 
 ## Baseline
 
@@ -13,60 +28,48 @@ Maximum memory alloc is 131064 according to memory.js.total.
 
 ## Minimal Usage
 
-[+4472] **14192 bytes**
+[+5056] **14776 bytes**
 
 		import { memory } from "system";
 	➕	import Register from "../../index.js"
-	➕	var reg = new Register();
-	➕	reg.newInt('a',1);
+	➕	const reg = new Register();
+	➕	const a = reg.newInt(1);
 		console.log(memory.js.used);
 
 ## Minimal +1 Usage
 
-[+1720] **15912 bytes**
+[+1888] **16664 bytes**
 
 		import { memory } from "system";
 		import Register from "../../index.js"
-		var reg = new Register();
-		reg.newInt('a',1);
-	➕	reg.newInt('b',1);
+		const reg = new Register();
+		const a = reg.newInt(1);
+	➕	const b = reg.newInt(1);
 		console.log(memory.js.used);
 
 ## Minimal +2 Usage
 
-[+1696] **17608 bytes** _(24 less bytes increase)_
+[+1880] **18544 bytes** _(8 less bytes increase)_
 
 		import { memory } from "system";
 		import Register from "../../index.js"
 		var reg = new Register();
-		reg.newInt('a',1);
-		reg.newInt('b',1);
-	➕	reg.newInt('c',1);
+		const reg = new Register();
+		const a = reg.newInt(1);
+		const b = reg.newInt(1);
+	➕	const c = reg.newInt(1);
 		console.log(memory.js.used);
 
 ## Minimal +3 Usage
 
-[+1688] **19296 bytes** _(8 less bytes increase)_
+[+1880] **20424 bytes** _(0 bytes delta on increase)_
 
 		import { memory } from "system";
 		import Register from "../../index.js"
 		var reg = new Register();
-		reg.newInt('a',1);
-		reg.newInt('b',1);
-		reg.newInt('c',1);
-	➕	reg.newInt('d',1);
-		console.log(memory.js.used);
-
-## Minimal +4 Usage
-
-[+1672] **20968 bytes** _(16 less bytes increase)_
-
-		import { memory } from "system";
-		import Register from "../../index.js"
-		var reg = new Register();
-		reg.newInt('a',1);
-		reg.newInt('b',1);
-		reg.newInt('c',1);
-		reg.newInt('d',1);
-	➕	reg.newInt('e',1);
+		const reg = new Register();
+		const a = reg.newInt(1);
+		const b = reg.newInt(1);
+		const c = reg.newInt(1);
+	➕	const d = reg.newInt(1);
 		console.log(memory.js.used);

--- a/readme.md
+++ b/readme.md
@@ -9,16 +9,16 @@ Pack, edit, and easily retrieve variables and binary data into an efficient memo
 `const reg = new Register(2);// 2x32 bits`
 
 ### Add a Variable
-`reg.newInt('hit points',7,100);// 7 bits long = max val of 127`
+`const hitPoints = reg.newInt(7, 100);// 7 bits long = max val of 127; set to 100`
 
 ### Modify a Variable
-`reg.write('hit points',4);`
+`reg.write(hitPoints, 4);`
 
 ### Read a Variable
-`reg.read('hit points');// 4`
+`reg.read(hitPoints);// 4`
 
 ### Increment a Variable
-`reg.write('hit points',reg.read('hit points')+1);`
+`reg.write(hitPoints, reg.read(hitPoints) + 1);`
 
 ## Why?
 Memory management is critical in Fitbit development. Despite the convenience of their JavaScript SDK, there are nuances that can bloat your memory usage badly.

--- a/tests.js
+++ b/tests.js
@@ -5,35 +5,35 @@ var reg = new Register(2,true);
 
 // create variables
 console.log('setting up vars');
-reg.newInt('energy',3,7);
-reg.newInt('hp',5,20);
-reg.newInt('coins',16,999);
-reg.newInt('lives',4,0xF);
+const energy = reg.newInt(3,7);
+const hp = reg.newInt(5,20);
+const coins = reg.newInt(16,999);
+const lives = reg.newInt(4,0xF);
 
 // change variables
 console.log('\nchanging values');
-reg.write('energy',2);
-reg.write('hp',11);
-reg.read('energy');
-reg.read('hp');
+reg.write(energy,2);
+reg.write(hp,11);
+reg.read(energy);
+reg.read(hp);
 
 // increment/decrement
 console.log('\ndecrement a variable');
-reg.write('lives',reg.read('lives')-1); reg.read('lives');
+reg.write(lives,reg.read(lives)-1); reg.read(lives);
 
 // wraps around indices automatically
 console.log('\nwraps around indices automatically');
-reg.newInt('boss health',8,0b10101010);
-console.log(reg._leftPad32(reg._reg[1]) + ' boss health');
+const bossHealth = reg.newInt(8,0b10101010);// 170
+console.log(reg._leftPad32(reg._reg[1]));
 
-console.log((reg.read('boss health') >>> 0).toString(2));
+console.log((reg.read(bossHealth) >>> 0).toString(2));
 
 // max out a variable; it clamps automatically
 console.log('\nclamps variables to prevent underflows and overflows');
-reg.newInt('item id',8,Infinity);
-reg.read('item id');
-reg.write('item id',-5);// all vars are unsigned, so this will clamp to 0.
-reg.read('item id');
+const itemId = reg.newInt(8,Infinity);
+reg.read(itemId);
+reg.write(itemId,-5);// all vars are unsigned, so this will clamp to 0.
+reg.read(itemId);
 
 // reg.read('energy');
 // reg.read('hp');


### PR DESCRIPTION
Lookup tables (objects) are expensive in terms of Fitbit memory, so I am trying to avoid them. Luckily, this solution is pretty elegant. Now just save return value of newInt() to recall later with read/write, or pass in an identical string.

updated test app, seems to be doing ok once garbage collection kicks in.
updated readme with new syntax